### PR TITLE
Correct error for exact match with dictionary word

### DIFF
--- a/src/detectors/levenshtein.ts
+++ b/src/detectors/levenshtein.ts
@@ -7,12 +7,12 @@ export class LevenshteinDetector extends BaseDetector {
     const result: DetectResult[] = [];
 
     this.tokens.forEach((token) => {
+      if (this.dictionary.some((word) => word === token.str)) {
+        return;
+      }
+
       const candidates = this.dictionary.filter((word) => {
         const distance = calcLevenshteinDistance(token.str, word);
-        if (distance === 0) {
-          return false;
-        }
-
         return distance <= this.threshold;
       });
 

--- a/test/index-test.ts
+++ b/test/index-test.ts
@@ -12,6 +12,12 @@ tester.run("textlint-rule-typo-detection", rule, {
         dictionary: ["world"],
       },
     },
+    {
+      text: "achieve",
+      options: {
+        dictionary: ["achieve", "achieved"],
+      },
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
## What

The error occurs even when there is an exact match with a word in the dictionary, so I fixed it.


Example.

```
$ cat .textlintrc.json
{
  "rules": {
    "typo-detection": {
      "dictionary": ["achieve", "achieved"]
    }
  }
}

$ pnpm exec textlint sample.md --format pretty-error
typo-detection: Is "achieve" perhaps "achieved" ?
/path/to/sample.md:1:2
        v
    0.
    1. "achieve" is ...
    2.
        ^

✖ 1 problem (1 error, 0 warnings)
```